### PR TITLE
feature(terra-components): import TerraComponentsModule directly

### DIFF
--- a/src/app/plugin-terra-basic.module.ts
+++ b/src/app/plugin-terra-basic.module.ts
@@ -39,7 +39,7 @@ import { OverviewViewComponent } from './views/example/overview/overview-view.co
         HttpClientModule,
         TranslationModule.forRoot(l10nConfig),
         RouterModule.forRoot([]),
-        TerraComponentsModule.forRoot(),
+        TerraComponentsModule,
         routing
     ],
     declarations: [


### PR DESCRIPTION
... since forRoot() is not available anymore

depends on https://github.com/plentymarkets/terra-components/pull/932